### PR TITLE
Feature: SignIn, SignUp, SignOut Flow

### DIFF
--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -1,7 +1,7 @@
 {
-  "expoServerPort": null,
-  "packagerPort": null,
-  "packagerPid": null,
+  "expoServerPort": 19000,
+  "packagerPort": 19001,
+  "packagerPid": 11997,
   "devToolsPort": 19002,
   "expoServerNgrokUrl": null,
   "packagerNgrokUrl": null,

--- a/.expo/packager-info.json
+++ b/.expo/packager-info.json
@@ -1,7 +1,7 @@
 {
-  "expoServerPort": 19000,
-  "packagerPort": 19001,
-  "packagerPid": 11997,
+  "expoServerPort": null,
+  "packagerPort": null,
+  "packagerPid": null,
   "devToolsPort": 19002,
   "expoServerNgrokUrl": null,
   "packagerNgrokUrl": null,

--- a/App.js
+++ b/App.js
@@ -3,7 +3,6 @@ import {AppLoading, Font} from 'expo';
 import {createRootNavigator} from "./src/Router";
 import {isSignedIn, onSignOut} from "./src/Auth";
 
-
 export default class App extends React.Component {
 
     state = {
@@ -19,8 +18,6 @@ export default class App extends React.Component {
             'montserrat-bold': require('./assets/fonts/Montserrat-Bold.otf'),
             'open-sans-bold': require('./assets/fonts/OpenSans-Bold.ttf'),
             'Ionicons' : require("@expo/vector-icons/fonts/Ionicons.ttf")});
-
-        await onSignOut();
 
         await isSignedIn()
             .then(res => this.setState({ signedIn: res }))

--- a/App.js
+++ b/App.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import {AppLoading, Font} from 'expo';
-import {SignedOutNavigator, SignedInNavigator} from "./src/Router";
+import {createRootNavigator} from "./src/Router";
+import {isSignedIn, onSignOut} from "./src/Auth";
 
 
 export default class App extends React.Component {
 
     state = {
-        isReady: false
+        isReady: false,
+        signedIn: false
     };
 
     async componentWillMount() {
@@ -16,8 +18,18 @@ export default class App extends React.Component {
             'montserrat-regular': require('./assets/fonts/Montserrat-Regular.otf'),
             'montserrat-bold': require('./assets/fonts/Montserrat-Bold.otf'),
             'open-sans-bold': require('./assets/fonts/OpenSans-Bold.ttf'),
-            'Ionicons' : require("@expo/vector-icons/fonts/Ionicons.ttf")}),
-        this.setState({ isReady: true })
+            'Ionicons' : require("@expo/vector-icons/fonts/Ionicons.ttf")});
+
+        await onSignOut();
+
+        await isSignedIn()
+            .then(res => this.setState({ signedIn: res }))
+            .catch(err => {
+                alert("Oops, an error occurred.");
+                console.log("App.js > isSignedIn() > ERROR: ", err);
+            });
+
+        this.setState({ isReady: true });
     }
 
     render() {
@@ -26,32 +38,8 @@ export default class App extends React.Component {
               <AppLoading/>
             );
         }
-        return (<SignedInNavigator />);
+
+        const RootNavigator = createRootNavigator(this.state.signedIn);
+        return <RootNavigator />;
     }
-
 }
-/*
-navigationOptions: ({ navigation }) => ({
-        tabBarIcon: ({ focused, horizontal, tintColor }) => {
-          const { routeName } = navigation.state;
-          let iconName;
-          if (routeName === 'Profile') {
-            iconName = `ios-information-circle${focused ? '' : '-outline'}`;
-          } else if (routeName === 'Hangouts') {
-            iconName = `ios-options${focused ? '' : '-outline'}`;
-          }
-  
-          // You can return any component that you like here! We usually use an
-          // icon component from react-native-vector-icons
-          return <Ionicons name={iconName} size={horizontal ? 20 : 25} color={tintColor} />;
-        },
-      }),
-(
-            <View>
-                <HangoutLanding />
-                <TabProp />
-            </View>
-        )
-                <FgProfile member={ MOCKED_MEMBER_DARIA_with_BANNER_and_AVATAR }/>
-
-*/

--- a/App.js
+++ b/App.js
@@ -1,67 +1,7 @@
 import React from 'react';
-import {View} from 'react-native';
 import {AppLoading, Font} from 'expo';
-// import { Nav } from './src/components/Nav/Nav'
-import Ionicons from 'react-native-vector-icons/Ionicons';
+import {SignedOutNavigator, SignedInNavigator} from "./src/Router";
 
-import {createBottomTabNavigator} from 'react-navigation';
-
-import {FgProfile} from "./src/pages/FgProfile";
-import {MOCKED_MEMBER_DARIA_with_BANNER_and_AVATAR} from "./src/test/MockedTypes";
-import {HangoutLanding} from "./src/pages/HangoutLanding";
-import {Menu} from './src/pages/Menu';
-import {Chapter} from './src/pages/Chapter';
-import {Events} from './src/pages/Events'
-// import getTheme from 'native-base';
-
-const mapNavigationStateParamsToProps = (FgProfile) => {
-    return class extends React.Component {
-        render() {
-            return (
-                <View style={{flex: 1}}>
-                    <FgProfile member={ MOCKED_MEMBER_DARIA_with_BANNER_and_AVATAR } />
-                </View>
-            );
-        };
-    }
-}
-const Nav =  createBottomTabNavigator(
-    {
-      Menu: Menu,
-      MyChapter: Chapter,
-      Hangouts: HangoutLanding,
-      Events: Events,
-      Profile: mapNavigationStateParamsToProps(FgProfile)
-    },
-    {
-    navigationOptions: ({ navigation }) => ({
-        tabBarIcon: ({ focused, horizontal, tintColor }) => {
-            const { routeName } = navigation.state;
-            let iconName;
-            if (routeName === 'Profile') {
-              iconName = `md-person`;
-            } else if (routeName === 'Hangouts') {
-              iconName = `md-people`;
-            } else if (routeName === 'Events') {
-              iconName = `md-calendar`
-            } else if (routeName === 'Menu') {
-              iconName = `md-menu`
-            } else if (routeName === 'MyChapter') {
-              iconName = `md-bonfire`
-            }
-    
-            // You can return any component that you like here! We usually use an
-            // icon component from react-native-vector-icons
-            return <Ionicons name={iconName} size={horizontal ? 20 : 25} color={tintColor} />;
-            // return <Image source={{ uri: iconName}} style={{height: 30, width: 30}} />; // size={horizontal ? 20 : 25} color={tintColor} 
-        },
-        }),
-      tabBarOptions: {
-        activeTintColor: 'tomato',
-        inactiveTintColor: 'gray',
-      },
-    }
-  );
 
 export default class App extends React.Component {
 
@@ -75,6 +15,7 @@ export default class App extends React.Component {
             'open-sans-regular': require('./assets/fonts/OpenSans-Regular.ttf'),
             'montserrat-regular': require('./assets/fonts/Montserrat-Regular.otf'),
             'montserrat-bold': require('./assets/fonts/Montserrat-Bold.otf'),
+            'open-sans-bold': require('./assets/fonts/OpenSans-Bold.ttf'),
             'Ionicons' : require("@expo/vector-icons/fonts/Ionicons.ttf")}),
         this.setState({ isReady: true })
     }
@@ -85,7 +26,7 @@ export default class App extends React.Component {
               <AppLoading/>
             );
         }
-        return (<Nav />);
+        return (<SignedInNavigator />);
     }
 
 }

--- a/app.json
+++ b/app.json
@@ -5,5 +5,12 @@
     "slug": "fg-demo",
     "privacy": "unlisted",
     "orientation": "portrait"
+  },
+  "ios":{
+    "infoPlist": {
+      "NSAppTransportSecurity": {
+        "NSAllowsArbitraryLoads": "true"
+      }
+    }
   }
 }

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -23,3 +23,7 @@ export const isSignedIn = () => {
             .catch(err => reject(err));
     });
 };
+
+export const dummySignInAuthorization = (username, password) => {
+    return (username.toLowerCase() === 'test' && password.toLowerCase() === 'test')
+};

--- a/src/Auth.js
+++ b/src/Auth.js
@@ -1,0 +1,25 @@
+import { AsyncStorage } from "react-native";
+
+export const USER_AUTH_KEY = "user-auth-key";
+
+export const onSignIn = () => {
+    AsyncStorage.setItem(USER_AUTH_KEY, "true");
+};
+
+export const onSignOut = () => {
+    AsyncStorage.removeItem(USER_AUTH_KEY);
+};
+
+export const isSignedIn = () => {
+    return new Promise((resolve, reject) => {
+        AsyncStorage.getItem(USER_AUTH_KEY, null)
+            .then(res => {
+                if (res !== null) {
+                    resolve(true);
+                } else {
+                    resolve(false);
+                }
+            })
+            .catch(err => reject(err));
+    });
+};

--- a/src/DataManager.js
+++ b/src/DataManager.js
@@ -1,0 +1,31 @@
+import {AsyncStorage} from "react-native";
+
+/*
+    Use this DataManager to persist non-encrypted data between application
+    launches. Use for non-sensitive information.
+ */
+
+// Storage Keys
+export const SIGNED_IN_MEMBER = "signed-in-member";
+
+export class DataManager {
+
+    static async setItemForKey(key, item) {
+        try {
+            return await AsyncStorage.setItem(key, JSON.stringify(item));
+        } catch (error) {
+            console.log("[ERROR - DataManager]: ", error.message);
+        }
+    }
+
+    static async getItemWithKey(key) {
+        try {
+            const retrievedItem =  await AsyncStorage.getItem(key, null);
+            return JSON.parse(retrievedItem);
+        } catch (error) {
+            console.log("[ERROR - DataManager]: ", error.message);
+        }
+    }
+
+
+}

--- a/src/DataManager.js
+++ b/src/DataManager.js
@@ -7,6 +7,7 @@ import {AsyncStorage} from "react-native";
 
 // Storage Keys
 export const SIGNED_IN_MEMBER = "signed-in-member";
+export const SIGNED_IN_MEMBER_ID = "signed-in-member-id";
 
 export class DataManager {
 
@@ -22,6 +23,14 @@ export class DataManager {
         try {
             const retrievedItem =  await AsyncStorage.getItem(key, null);
             return JSON.parse(retrievedItem);
+        } catch (error) {
+            console.log("[ERROR - DataManager]: ", error.message);
+        }
+    }
+
+    static async removeItemWithKey(key) {
+        try {
+            await AsyncStorage.removeItem(key);
         } catch (error) {
             console.log("[ERROR - DataManager]: ", error.message);
         }

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,0 +1,54 @@
+import {createBottomTabNavigator, createStackNavigator} from "react-navigation";
+
+import { CreateProfile } from "./pages/CreateProfile";
+import {Login} from "./pages/Login";
+import {Menu} from "./pages/Menu";
+import {Chapter} from "./pages/Chapter";
+import {HangoutLanding} from "./pages/HangoutLanding";
+import {Events} from "./pages/Events";
+import {FgProfile} from "./pages/FgProfile";
+import Ionicons from "react-native-vector-icons/Ionicons";
+import React from "react";
+
+export const SignedOutNavigator = createStackNavigator({
+    SignIn: { screen: Login },
+    SignUp: { screen: CreateProfile }
+}, { navigationOptions: { header: null }});
+
+export const SignedInNavigator =  createBottomTabNavigator(
+    {
+        Menu: Menu,
+        MyChapter: Chapter,
+        Hangouts: HangoutLanding,
+        Events: Events,
+        Profile: FgProfile
+    },
+    {
+        navigationOptions: ({ navigation }) => ({
+            tabBarIcon: ({ focused, horizontal, tintColor }) => {
+                const { routeName } = navigation.state;
+                let iconName;
+                if (routeName === 'Profile') {
+                    iconName = `md-person`;
+                } else if (routeName === 'Hangouts') {
+                    iconName = `md-people`;
+                } else if (routeName === 'Events') {
+                    iconName = `md-calendar`
+                } else if (routeName === 'Menu') {
+                    iconName = `md-menu`
+                } else if (routeName === 'MyChapter') {
+                    iconName = `md-bonfire`
+                }
+
+                // You can return any component that you like here! We usually use an
+                // icon component from react-native-vector-icons
+                return <Ionicons name={iconName} size={horizontal ? 20 : 25} color={tintColor} />;
+                // return <Image source={{ uri: iconName}} style={{height: 30, width: 30}} />; // size={horizontal ? 20 : 25} color={tintColor}
+            },
+        }),
+        tabBarOptions: {
+            activeTintColor: 'tomato',
+            inactiveTintColor: 'gray',
+        },
+    }
+);

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,4 +1,4 @@
-import {createBottomTabNavigator, createStackNavigator} from "react-navigation";
+import {createBottomTabNavigator, createStackNavigator, createSwitchNavigator} from "react-navigation";
 
 import { CreateProfile } from "./pages/CreateProfile";
 import {Login} from "./pages/Login";
@@ -9,6 +9,18 @@ import {Events} from "./pages/Events";
 import {FgProfile} from "./pages/FgProfile";
 import Ionicons from "react-native-vector-icons/Ionicons";
 import React from "react";
+
+export const createRootNavigator = (signedIn = false) => {
+    return createSwitchNavigator(
+        {
+            SignedIn: { screen: SignedInNavigator },
+            SignedOut: { screen: SignedOutNavigator }
+        },
+        {
+            initialRouteName: signedIn ? "SignedIn" : "SignedOut"
+        }
+    );
+};
 
 export const SignedOutNavigator = createStackNavigator({
     SignIn: { screen: Login },

--- a/src/pages/CreateProfile.js
+++ b/src/pages/CreateProfile.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleSheet, View, Text, Image, ScrollView, TextInput, Picker} from 'react-native';
-import {SCREEN_WIDTH} from "../utils/sharedConstants";
+import {PLACEHOLDER_TEXT_COLOR, SCREEN_WIDTH} from "../utils/sharedConstants";
 import {FgButton} from "../components/FgButton";
 import {FgMember} from "../types/FgMember";
 import {FgProfileService} from "../services/FgProfileService";
@@ -29,7 +29,6 @@ export class CreateProfile extends React.Component {
     }
 
     render() {
-        const placeHolderTextColor = '#3A6A75';
         return (
 
             <KeyboardAwareScrollView
@@ -58,7 +57,7 @@ export class CreateProfile extends React.Component {
                     <TextInput
                         style={styles.textInputStyle}
                         placeholder={'First Name'}
-                        placeholderTextColor={placeHolderTextColor}
+                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
                         onChangeText={(text) => this.setState({firstName: text})}
                         value={this.state.firstName}/>
                 </View>
@@ -68,7 +67,7 @@ export class CreateProfile extends React.Component {
                     <TextInput
                         style={styles.textInputStyle}
                         placeholder={'Last Name'}
-                        placeholderTextColor={placeHolderTextColor}
+                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
                         onChangeText={(text) => this.setState({lastName: text})}
                         value={this.state.lastName}/>
                 </View>
@@ -78,7 +77,7 @@ export class CreateProfile extends React.Component {
                     <TextInput
                         style={styles.textInputStyle}
                         placeholder={'School Name'}
-                        placeholderTextColor={placeHolderTextColor}
+                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
                         onChangeText={(text) => this.setState({schoolName: text})}
                         value={this.state.schoolName}/>
                 </View>
@@ -121,7 +120,7 @@ export class CreateProfile extends React.Component {
     }
 
     async handleSubmit() {
-        const {navigate} = this.props.navigation;
+        const { navigate } = this.props.navigation;
         const fgMember = new FgMember(this.state.firstName, this.state.lastName, this.state.schoolName, this.state.gradYear, null, null, this.state.inspirationText);
         const id = await this.service.createMember(fgMember);
         console.log('id: ', id);
@@ -135,11 +134,6 @@ const styles = StyleSheet.create({
     scrollViewStyle: {
         flex: 1,
         opacity: 1,
-        backgroundColor: 'white'
-    },
-    mainViewStyle: {
-        flex: 1,
-        alignItems: 'center',
         backgroundColor: 'white'
     },
     subViewStyle: {

--- a/src/pages/CreateProfile.js
+++ b/src/pages/CreateProfile.js
@@ -5,6 +5,8 @@ import {FgButton} from "../components/FgButton";
 import {FgMember} from "../types/FgMember";
 import {FgProfileService} from "../services/FgProfileService";
 import {KeyboardAwareScrollView} from "react-native-keyboard-aware-scroll-view";
+import {DataManager, SIGNED_IN_MEMBER} from "../DataManager";
+import {onSignIn} from "../Auth";
 
 export class CreateProfile extends React.Component {
 
@@ -120,11 +122,20 @@ export class CreateProfile extends React.Component {
     }
 
     async handleSubmit() {
+        // Grab the navigator
         const { navigate } = this.props.navigation;
-        const fgMember = new FgMember(this.state.firstName, this.state.lastName, this.state.schoolName, this.state.gradYear, null, null, this.state.inspirationText);
-        const id = await this.service.createMember(fgMember);
-        console.log('id: ', id);
-        navigate('Profile', {member: fgMember});
+        // Create member object from form field values
+        const fgMember = new FgMember(this.state.firstName, this.state.lastName,
+            this.state.schoolName, this.state.gradYear, null, null, this.state.inspirationText);
+        // Create member through backend service, store member to local storage, and proceed to SignedIn navigator
+        await this.service.createMember(fgMember)
+            .then( (id) => console.log("[CreateProfile]: FgMember created successfully, id: ", id))
+            .then( () => DataManager.setItemForKey(SIGNED_IN_MEMBER, fgMember) )
+            .then( (member) => console.log("[CreateProfile]: Local storage successful. FgMember: ", member))
+            .then( () => onSignIn() )
+            .then( () => navigate("SignedIn"))
+            .catch((error) => console.log("[ERROR - CreateProfile > handleSubmit()]: ", error.message))
+
     }
 
 

--- a/src/pages/FgProfile.js
+++ b/src/pages/FgProfile.js
@@ -3,7 +3,8 @@ import {ScrollView, StyleSheet, Text, View} from 'react-native';
 import {Avatar} from "../components/Avatar";
 import {Banner} from "../components/Banner";
 import {BANNER_HEIGHT_WIDTH_RATIO, SCREEN_HEIGHT, SCREEN_WIDTH} from "../utils/sharedConstants";
-import {MOCKED_MEMBER_DARIA_no_AVATAR_no_BANNER} from "../test/MockedTypes";
+import {DataManager, SIGNED_IN_MEMBER} from "../DataManager";
+import {FgMember} from "../types/FgMember";
 
 //TODO: Create AvatarGroup component to display chapter sisters.
 //TODO: Create FgButton to allow 'View All' click to see all chapter sisters.
@@ -11,9 +12,50 @@ import {MOCKED_MEMBER_DARIA_no_AVATAR_no_BANNER} from "../test/MockedTypes";
 //TODO: Status bar background should be white not translucent
 
 export class FgProfile extends React.Component {
-    member = MOCKED_MEMBER_DARIA_no_AVATAR_no_BANNER; //stub member for now
+
+    constructor() {
+        super();
+        this.state = {
+            loading: 'initial',
+            member: null
+        }
+    }
+
+    // Load current signed in member from local storage.
+    async loadFgMember() {
+        return DataManager.getItemWithKey(SIGNED_IN_MEMBER)
+            .catch((error) => console.log("[ERROR - FgProfile > loadFgMember() ]: ", error.message));
+    }
+
+    componentDidMount() {
+        this.setState({ loading: 'true' });
+        this.loadFgMember()
+            .then( (data) => {
+                const fgMember = new FgMember(
+                    data.firstName,
+                    data.lastName,
+                    data.schoolName,
+                    data.gradYear,
+                    data.bannerSource,
+                    data.avatarSource,
+                    data.inspiration
+                );
+                this.setState({member: fgMember, loading: 'false'});
+            })
+            .catch( (error) => console.log(error.message));
+    }
 
     render() {
+
+        if( this.state.loading === 'initial' ) {
+            return <Text>Initializing</Text>
+        }
+
+        if( this.state.loading === 'true' ) {
+            return <Text>Loading</Text>
+        }
+
+        console.log("LOADED member: ", this.state.member);
         const bannerHeight = SCREEN_WIDTH * BANNER_HEIGHT_WIDTH_RATIO;
         return (
             //Wrap entire profile in a ScrollView
@@ -22,21 +64,21 @@ export class FgProfile extends React.Component {
             <View style={styles.container}>
 
                 // Render the Banner
-                <Banner source={this.member.bannerSource}/>
+                <Banner source={this.state.member.bannerSource}/>
 
                 // Render the Avatar
                 <View style={{ top: bannerHeight / 2, position: 'absolute'}}>
                     <Avatar
                         avatarSize={'large'}
-                        name={this.member.fullName()}
-                        source={this.member.avatarSource}/>
+                        name={this.state.member.fullName()}
+                        source={this.state.member.avatarSource}/>
                 </View>
 
                 // Render the member's name, school, and graduation year
                 <Text style={[styles.textContainer, { top: bannerHeight * 1.5 }]}>
-                    <Text style={styles.nameLabel}>{this.member.fullName()}</Text>{'\n'}
-                    <Text style={styles.schoolLabel}>{this.member.schoolName}</Text>{'\n'}
-                    <Text style={styles.gradYearLabel}>Class of {this.member.gradYear}</Text>{'\n'}
+                    <Text style={styles.nameLabel}>{this.state.member.fullName()}</Text>{'\n'}
+                    <Text style={styles.schoolLabel}>{this.state.member.schoolName}</Text>{'\n'}
+                    <Text style={styles.gradYearLabel}>Class of {this.state.member.gradYear}</Text>{'\n'}
                 </Text>
 
                 // Render the 'Inspiration' title with horizontal dividers on each side
@@ -48,7 +90,7 @@ export class FgProfile extends React.Component {
 
                 // Render the member's inspiration block
                 <Text style={[styles.inspirationBlock, {top: bannerHeight * 2.6 }]}>
-                    {this.member.inspiration}
+                    {this.state.member.inspiration}
                 </Text>
 
 

--- a/src/pages/FgProfile.js
+++ b/src/pages/FgProfile.js
@@ -1,10 +1,12 @@
 import React from 'react';
-import {ScrollView, StyleSheet, Text, View} from 'react-native';
+import {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
 import {Avatar} from "../components/Avatar";
 import {Banner} from "../components/Banner";
 import {BANNER_HEIGHT_WIDTH_RATIO, SCREEN_HEIGHT, SCREEN_WIDTH} from "../utils/sharedConstants";
-import {DataManager, SIGNED_IN_MEMBER} from "../DataManager";
+import {DataManager, SIGNED_IN_MEMBER, SIGNED_IN_MEMBER_ID} from "../DataManager";
 import {FgMember} from "../types/FgMember";
+import {MOCKED_MEMBER_DARIA_with_BANNER_and_AVATAR} from "../test/MockedTypes";
+import {onSignIn, onSignOut} from "../Auth";
 
 //TODO: Create AvatarGroup component to display chapter sisters.
 //TODO: Create FgButton to allow 'View All' click to see all chapter sisters.
@@ -18,7 +20,8 @@ export class FgProfile extends React.Component {
         this.state = {
             loading: 'initial',
             member: null
-        }
+        };
+        this.handleSignOut.bind(this);
     }
 
     // Load current signed in member from local storage.
@@ -40,7 +43,8 @@ export class FgProfile extends React.Component {
                     data.avatarSource,
                     data.inspiration
                 );
-                this.setState({member: fgMember, loading: 'false'});
+                //this.setState({member: fgMember, loading: 'false'});
+                this.setState({member: fgMember, loading: false});
             })
             .catch( (error) => console.log(error.message));
     }
@@ -59,66 +63,79 @@ export class FgProfile extends React.Component {
         const bannerHeight = SCREEN_WIDTH * BANNER_HEIGHT_WIDTH_RATIO;
         return (
             //Wrap entire profile in a ScrollView
-            <ScrollView
-                style={styles.scrollViewStyle}>
-            <View style={styles.container}>
+            <ScrollView style={styles.scrollViewStyle} bounces={false}>
 
-                // Render the Banner
-                <Banner source={this.state.member.bannerSource}/>
-
-                // Render the Avatar
-                <View style={{ top: bannerHeight / 2, position: 'absolute'}}>
-                    <Avatar
-                        avatarSize={'large'}
-                        name={this.state.member.fullName()}
-                        source={this.state.member.avatarSource}/>
+                //Banner
+                <View style={styles.subViewStyle}>
+                    <View style={{position: 'absolute'}}>
+                        <Banner source={this.state.member.bannerSource}/>
+                    </View>
                 </View>
 
-                // Render the member's name, school, and graduation year
-                <Text style={[styles.textContainer, { top: bannerHeight * 1.5 }]}>
-                    <Text style={styles.nameLabel}>{this.state.member.fullName()}</Text>{'\n'}
-                    <Text style={styles.schoolLabel}>{this.state.member.schoolName}</Text>{'\n'}
-                    <Text style={styles.gradYearLabel}>Class of {this.state.member.gradYear}</Text>{'\n'}
-                </Text>
-
-                // Render the 'Inspiration' title with horizontal dividers on each side
-                <View style={[styles.inspirationTitle, {top: bannerHeight * 2.345}]}>
-                    <View style={styles.inspirationLine}/>
-                    <Text style={styles.inspirationLabel}>  Inspiration  </Text>
-                    <View style={styles.inspirationLine}/>
+                //Avatar
+                <View style={styles.subViewStyle}>
+                    <View style={{marginTop: (bannerHeight/2)}}>
+                        <Avatar
+                            avatarSize={'large'}
+                            name={this.state.member.fullName()}
+                            source={this.state.member.avatarSource}/>
+                    </View>
                 </View>
 
-                // Render the member's inspiration block
-                <Text style={[styles.inspirationBlock, {top: bannerHeight * 2.6 }]}>
-                    {this.state.member.inspiration}
-                </Text>
+                //Name, School, and Grad Year
+                <View style={styles.subViewStyle}>
+                    <Text style={{marginTop: 20, textAlign: 'center', color: '#818282'}}>
+                        <Text style={[styles.nameLabel, {margin: 3}]}>{this.state.member.fullName()}</Text>{'\n'}
+                        <Text style={[styles.schoolLabel, {margin: 2}]}>{this.state.member.schoolName}</Text>{'\n'}
+                        <Text style={[styles.gradYearLabel, {margin: 1}]}>Class of {this.state.member.gradYear}</Text>{'\n'}
+                    </Text>
+                </View>
 
+                //Inspiration Title
+                <View style={styles.subViewStyle}>
+                    <View style={[styles.inspirationTitle, {marginTop: 60}]}>
+                        <View style={styles.inspirationLine}/>
+                        <Text style={styles.inspirationLabel}>  Inspiration  </Text>
+                        <View style={styles.inspirationLine}/>
+                    </View>
+                </View>
 
-            </View>
+                //Inspiration Block
+                <View style={styles.subViewStyle}>
+                    <Text style={[styles.inspirationBlock, {marginTop: 40 }]}>
+                        {this.state.member.inspiration}
+                    </Text>
+                </View>
+
+                //Sign-Out button placed here temporarily to allow for testing of user sign-in/out flow
+                <View style={styles.subViewStyle}>
+                    <Button title={"Sign Out"} onPress={() => this.handleSignOut()}/>
+                </View>
 
             </ScrollView>
         );
     }
 
-}
+    handleSignOut() {
+        const { navigation } = this.props;
+        DataManager.removeItemWithKey(SIGNED_IN_MEMBER_ID)
+            .then( () => DataManager.removeItemWithKey(SIGNED_IN_MEMBER))
+            .then(() => onSignOut())
+            .then(() => navigation.navigate("SignedOut"))
+            .catch( (error) => console.log(error.message));
 
+    }
+
+}
 const styles = StyleSheet.create({
     scrollViewStyle: {
-        height: SCREEN_HEIGHT,
-        width: SCREEN_WIDTH,
-        opacity: 1,
-        backgroundColor: '#ffffff'
-    },
-    container: {
         flex: 1,
-        alignItems: 'center',
-        position: 'relative',
-        backgroundColor: '#ffffff'
+        opacity: 1,
+        backgroundColor: 'white'
     },
-    textContainer: {
-        position: 'absolute',
-        color: '#818282',
-        textAlign: 'center'
+    subViewStyle: {
+        flex: 1,
+        alignItems: 'center'
     },
     nameLabel: {
         fontFamily: 'montserrat-light',
@@ -133,7 +150,6 @@ const styles = StyleSheet.create({
         fontSize: 14
     },
     inspirationTitle: {
-        position: 'absolute',
         flexDirection: 'row',
         alignContent: 'center',
         justifyContent: 'center'
@@ -155,7 +171,7 @@ const styles = StyleSheet.create({
         fontSize: 14,
         textAlign: 'left',
         color: '#818282',
-        position: 'absolute',
         margin: 20
     }
+
 });

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import {StyleSheet, Text, TextInput, View, Button} from 'react-native';
+import {FgButton} from "../components/FgButton";
+import {PLACEHOLDER_TEXT_COLOR, SCREEN_WIDTH} from "../utils/sharedConstants";
+
+export class Login extends React.Component {
+
+    constructor() {
+        super();
+        this.handleSignUp.bind(this);
+        this.handleSignIn.bind(this);
+    }
+
+    render() {
+        return (
+            <View style={styles.mainViewStyle}>
+
+                <View style={[styles.subViewStyle, {marginTop: 25}]}>
+                    <Text>Sign In</Text>
+                </View>
+
+                // Username
+                <View style={styles.subViewStyle}>
+                    <TextInput
+                        style={styles.textInputStyle}
+                        placeholder={'Username'}
+                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}/>
+                </View>
+
+                // Password
+                <View style={[styles.subViewStyle, {marginTop: 25}]}>
+                    <TextInput
+                        style={styles.textInputStyle}
+                        placeholder={'Password'}
+                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
+                        secureTextEntry={true}/>
+                </View>
+
+                // Sign in button
+                <View style={styles.subViewStyle}>
+                    <View style={styles.submitButtonStyle}>
+                        <FgButton onPress={() => this.handleSignIn()} title={"Sign In"}/>
+                    </View>
+                </View>
+
+                // Sign up button
+                <View style={styles.subViewStyle}>
+                    <Button title={"Sign up"} onPress={() => this.handleSignUp()}/>
+                </View>
+
+            </View>
+        );
+    }
+    handleSignIn() {
+        console.log('User clicked sign in.');
+    }
+    handleSignUp() {
+        const { navigate } = this.props.navigation;
+        navigate("SignUp");
+    }
+}
+
+const styles = StyleSheet.create({
+    mainViewStyle: {
+        flex: 1,
+        opacity: 1,
+        backgroundColor: 'white'
+    },
+    subViewStyle: {
+        flex: 1,
+        alignItems: 'center',
+        margin: 5
+    },
+    textInputStyle: {
+        fontFamily: 'open-sans-regular',
+        fontSize: 18,
+        borderColor: '#BDCDD1',
+        borderBottomWidth: 1,
+        width: SCREEN_WIDTH * 0.78,
+        height: 35,
+        lineHeight: 20,
+        margin: 20
+    },
+    submitButtonStyle: {
+        width: '50%',
+        marginTop: 20,
+        marginBottom: 40
+    }
+});
+

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -52,7 +52,7 @@ export class Login extends React.Component {
         );
     }
     handleSignIn() {
-        console.log('User clicked sign in.');
+        console.log('Login not implemented.');
     }
     handleSignUp() {
         const { navigate } = this.props.navigation;

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,12 +1,19 @@
 import React from 'react';
-import {StyleSheet, Text, TextInput, View, Button} from 'react-native';
+import {Alert, Button, Image, StyleSheet, Text, TextInput, View} from 'react-native';
 import {FgButton} from "../components/FgButton";
 import {PLACEHOLDER_TEXT_COLOR, SCREEN_WIDTH} from "../utils/sharedConstants";
+import {dummySignInAuthorization, onSignIn} from "../Auth";
+import {DataManager, SIGNED_IN_MEMBER} from "../DataManager";
+import {MOCKED_MEMBER_DARIA_with_BANNER_and_AVATAR} from "../test/MockedTypes";
 
 export class Login extends React.Component {
 
     constructor() {
         super();
+        this.state = {
+            username: '',
+            password: ''
+        };
         this.handleSignUp.bind(this);
         this.handleSignIn.bind(this);
     }
@@ -15,44 +22,66 @@ export class Login extends React.Component {
         return (
             <View style={styles.mainViewStyle}>
 
-                <View style={[styles.subViewStyle, {marginTop: 25}]}>
-                    <Text>Sign In</Text>
-                </View>
+                <View style={[styles.subViewStyle, {paddingTop: 87}]}>
+                    // FG Logo
+                    <Image style={{width: SCREEN_WIDTH * 0.38, height: 35}} source={require('../../assets/images/fearlesslyGirl_logo.jpg')}/>
+                    // Page Title
+                    <Text style={{
+                        fontFamily: 'montserrat-light',
+                        fontSize: 22,
+                        color: '#818282',
+                        textAlign: 'center',
+                        marginTop: 5
+                    }}>Sign in.</Text>
 
-                // Username
-                <View style={styles.subViewStyle}>
-                    <TextInput
-                        style={styles.textInputStyle}
-                        placeholder={'Username'}
-                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}/>
-                </View>
+                    // Login section
+                    <View style={{marginTop: 30}}>
+                        //Username
+                        <TextInput
+                            style={styles.textInputStyle}
+                            placeholder={'Username'}
+                            placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
+                            onChangeText={(text) => this.setState({username: text})}
+                            value={this.state.username}/>
 
-                // Password
-                <View style={[styles.subViewStyle, {marginTop: 25}]}>
-                    <TextInput
-                        style={styles.textInputStyle}
-                        placeholder={'Password'}
-                        placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
-                        secureTextEntry={true}/>
-                </View>
+                        //Password
+                        <TextInput
+                            style={styles.textInputStyle}
+                            placeholder={'Password'}
+                            placeholderTextColor={PLACEHOLDER_TEXT_COLOR}
+                            secureTextEntry={true}
+                            onChangeText={(text) => this.setState({password: text})}
+                            value={this.state.password}/>
+                    </View>
 
-                // Sign in button
-                <View style={styles.subViewStyle}>
-                    <View style={styles.submitButtonStyle}>
+                    <View style={{width: SCREEN_WIDTH / 2, marginTop: 25, marginBottom: 15}}>
                         <FgButton onPress={() => this.handleSignIn()} title={"Sign In"}/>
                     </View>
+
+                    <Button title={"Sign up"} onPress={() => this.handleSignUp()}/>
+
                 </View>
 
-                // Sign up button
-                <View style={styles.subViewStyle}>
-                    <Button title={"Sign up"} onPress={() => this.handleSignUp()}/>
-                </View>
+
 
             </View>
         );
     }
-    handleSignIn() {
-        console.log('Login not implemented.');
+    async handleSignIn() {
+        if(dummySignInAuthorization(this.state.username, this.state.password)) {
+            const { navigation } = this.props;
+            await DataManager.setItemForKey(SIGNED_IN_MEMBER, MOCKED_MEMBER_DARIA_with_BANNER_and_AVATAR)
+                .then(() => onSignIn())
+                .then(() => navigation.navigate("SignedIn"))
+                .catch( (error) => console.log("[ERROR - Login > handleSignIn()]:", error.message));
+        }else {
+            Alert.alert(
+                'Oops!',
+                'Invalid username and/or password.',
+                [{text: 'Ok', onPress: () => console.log('Cancel Pressed'), style: 'cancel'}],
+                { cancelable: false }
+            );
+        }
     }
     handleSignUp() {
         const { navigate } = this.props.navigation;

--- a/src/services/FgProfileService.js
+++ b/src/services/FgProfileService.js
@@ -2,27 +2,26 @@ import {FgMember} from "../types/FgMember";
 
 export class FgProfileService {
 
-    async createMember(member) {
-        try {
-            let response = await fetch('http://localhost:5000/api/v1/profile', {
-                method: 'POST',
-                headers: {
-                    Accept: 'application/json',
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    firstName: member.firstName,
-                    lastName: member.lastName,
-                    schoolName: member.schoolName,
-                    gradYear: member.gradYear,
-                    inspiration: member.inspiration
-                })
-            });
-            let responseJSON = await response.toJSON();
-            return responseJSON.id;
-        } catch(error) {
-            console.log("[ERROR - FgProfileService]: ", error.message)
-        }
+    createMember(member) {
+        return fetch('http://localhost:5000/api/v1/profile/', {
+            method: 'POST',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                firstName: member.firstName ? member.firstName : null,
+                lastName: member.lastName ? member.lastName : null,
+                schoolName: member.schoolName ? member.schoolName : null,
+                gradYear: member.gradYear ? member.gradYear : null,
+                inspiration: member.inspiration ? member.inspiration : null
+            })
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                return data.id;
+            })
+            .catch( (error) => console.log(error.message));
     }
 
 }

--- a/src/services/FgProfileService.js
+++ b/src/services/FgProfileService.js
@@ -3,25 +3,26 @@ import {FgMember} from "../types/FgMember";
 export class FgProfileService {
 
     async createMember(member) {
-        return fetch('http://localhost:5000/api/v1/profile', {
-            method: 'POST',
-            headers: {
-                Accept: 'application/json',
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                firstName: member.firstName,
-                lastName: member.lastName,
-                schoolName: member.schoolName,
-                gradYear: member.gradYear,
-                inspiration: member.inspiration
-            }) })
-            .then(response => response.json())
-            .then(responseJSON => {
-                return responseJSON.id;
-            })
-            .catch(error => console.log('FgProfileService: ', error));
+        try {
+            let response = await fetch('http://localhost:5000/api/v1/profile', {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    firstName: member.firstName,
+                    lastName: member.lastName,
+                    schoolName: member.schoolName,
+                    gradYear: member.gradYear,
+                    inspiration: member.inspiration
+                })
+            });
+            let responseJSON = await response.toJSON();
+            return responseJSON.id;
+        } catch(error) {
+            console.log("[ERROR - FgProfileService]: ", error.message)
+        }
     }
-
 
 }

--- a/src/utils/sharedConstants.js
+++ b/src/utils/sharedConstants.js
@@ -4,6 +4,8 @@ export const SCREEN_WIDTH = Dimensions.get('window').width;
 export const SCREEN_HEIGHT = Dimensions.get('window').height;
 export const BANNER_HEIGHT_WIDTH_RATIO = 0.45;
 
+export const PLACEHOLDER_TEXT_COLOR = '#3A6A75';
+
 export const AVATAR_BG_COLORS = [
     '#FFAACC',
     '#FFBBDD',


### PR DESCRIPTION
- Moved all Navigators to new Router.js file.
- Created Login page with 'Sign-up' Button linking it to CreateProfile.
- Created a SignedIn navigator for main Tabbed Navigation, a SignedOut Navigator with Login and CreateProfile pages, and a RootNavigator which determines which one to display based on stubbed out authentication logic in new Auth.js file. 
- Created a DataManager class which uses React's AsyncStorage to persist data locally on phone using Key/Value pairs. So far its only storing the data of the signed in User. This way FgProfile can pick it up without needing to be passed in the params. 
- CreateProfile is fully integrated with the backend, a submit will not succeed without the server running.
- Login is using a stubbed out dummy authentication function from Auth.js. Log in with username: test and password: test to sign in as Mocked_Daria_Quinn. Anything else will display error message.  
- Added a Sign-out button to FgProfile so the entire flow can be tested in one run. 

**NOTE**:
- This will only work on iOS simulator not on actual phone. (Haven't test Android). I wasn't able to hit the profile endpoint for weeks and the problem is that iOS does not allow HTTP requests by default, only HTTPS. In order to enable HTTP requests I needed to add the following entry to app.json:
"ios": { "infoPlist": { "NSAppTransportSecurity":  {  "NSAllowsArbitraryLoads": "true"  }   }  }
This allowed me to hit the endpoint using the simulator but it still fails when on the actual device. 
